### PR TITLE
Auto Create Repo

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -84,6 +84,7 @@ def build(name, arch, tag, publish):
             "tags": [
                 "git-${DRONE_COMMIT_SHA:0:7}-" + arch,
             ],
+            "create_repository": True,
         },
     }
 


### PR DESCRIPTION
adds the create_repository setting to the build step.

```
  settings:
    access_key:
      from_secret: ecr_access_key
    build_args:
    - GIT_COMMIT
    - VERSION
    create_repository: true
    registry:
      from_secret: ecr_registry
    repo: ${DRONE_REPO_NAME}
    secret_key:
      from_secret: ecr_secret_key
    tags:
    - git-${DRONE_COMMIT_SHA:0:7}-arm64
    - ${DRONE_TAG}-arm64
```
