### PR TITLE
INFRA-3446 add tests and handler

### DIFF
--- a/internal/admission/handler.go
+++ b/internal/admission/handler.go
@@ -50,11 +50,6 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	if out == nil {
-		log.Error(fmt.Errorf("failed to decode sensor request: %s", req.Name), "")
-		return admission.Errored(http.StatusBadRequest, fmt.Errorf("Nil sensor request"))
-	}
-
 	defaultRate, err := h.rlg.RateLimit(out.Namespace)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("Cannot determine default ratelimit for namespace: %s", out.Namespace))

--- a/internal/admission/handler.go
+++ b/internal/admission/handler.go
@@ -1,0 +1,84 @@
+package admission
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	sensorv1alpha1 "github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1"
+	"github.com/kanopy-platform/argoslower/pkg/ratelimit"
+)
+
+type Handler struct {
+	rlg     RateLimitGetter
+	drlc    *ratelimit.RateLimitCalculator
+	decoder *admission.Decoder
+}
+
+func NewHandler(rlg RateLimitGetter, drlc *ratelimit.RateLimitCalculator) *Handler {
+	return &Handler{
+		rlg:  rlg,
+		drlc: drlc,
+	}
+}
+
+func (h *Handler) SetupWithManager(m manager.Manager) {
+	m.GetWebhookServer().Register("/mutate", &webhook.Admission{Handler: h})
+}
+
+func (h *Handler) InjectDecoder(decoder *admission.Decoder) error {
+	if decoder == nil {
+		return fmt.Errorf("decoder cannot be nil")
+	}
+	h.decoder = decoder
+	return nil
+}
+
+func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	log := log.FromContext(ctx)
+
+	out := &sensorv1alpha1.Sensor{}
+
+	if err := h.decoder.Decode(req, out); err != nil {
+		log.Error(err, fmt.Sprintf("failed to decode sensor request: %s", req.Name))
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if out == nil {
+		log.Error(fmt.Errorf("failed to decode sensor request: %s", req.Name), "")
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("Nil sensor request"))
+	}
+
+	defaultRate, err := h.rlg.RateLimit(out.Namespace)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("Cannot determine default ratelimit for namespace: %s", out.Namespace))
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	ts := []sensorv1alpha1.Trigger{}
+	for _, trigger := range out.Spec.Triggers {
+		if trigger.Template != nil && trigger.Template.K8s != nil {
+			rate := h.drlc.Calculate(defaultRate, trigger.RateLimit)
+			trigger.RateLimit = &rate
+		}
+
+		ts = append(ts, trigger)
+	}
+
+	out.Spec.Triggers = ts
+
+	jsonSensor, err := json.Marshal(out)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("failed to marshal gateway: %s", out.Name))
+		return admission.Errored(http.StatusInternalServerError, err)
+
+	}
+	return admission.PatchResponseFromRaw(req.Object.Raw, jsonSensor)
+
+}

--- a/internal/admission/handler_test.go
+++ b/internal/admission/handler_test.go
@@ -69,10 +69,10 @@ func TestSensorMutationHook(t *testing.T) {
 	}
 
 	tests := []struct {
-		description string
-		trigger     sensor.Trigger
-		ns          string
-		expected    float64
+		description         string
+		trigger             sensor.Trigger
+		ns                  string
+		expectedRatePerUnit float64
 	}{
 		{
 			description: "Trigger w/o k8s target",
@@ -125,8 +125,8 @@ func TestSensorMutationHook(t *testing.T) {
 				},
 				RateLimit: testRate,
 			},
-			ns:       "novalue",
-			expected: 1,
+			ns:                  "novalue",
+			expectedRatePerUnit: 1,
 		},
 		{
 			description: "Trigger w/ too big k8s target and rate",
@@ -140,7 +140,7 @@ func TestSensorMutationHook(t *testing.T) {
 					RequestsPerUnit: int32(100),
 				},
 			},
-			expected: 2,
+			expectedRatePerUnit: 2,
 		},
 	}
 
@@ -170,10 +170,10 @@ func TestSensorMutationHook(t *testing.T) {
 		assert.True(t, resp.Allowed, "request should be allowed")
 
 		//test patch bytes
-		assert.True(t, (len(resp.Patches) > 0) == (test.expected > 0), fmt.Sprintf("%s mutation expected", test.description))
+		assert.True(t, (len(resp.Patches) > 0) == (test.expectedRatePerUnit > 0), fmt.Sprintf("%s mutation expected", test.description))
 		for _, patch := range resp.Patches {
 			assert.Equal(t, "/spec/triggers/0/rateLimit/requestsPerUnit", patch.Path)
-			assert.Equal(t, float64(test.expected), patch.Value)
+			assert.Equal(t, float64(test.expectedRatePerUnit), patch.Value)
 		}
 	}
 }

--- a/internal/admission/handler_test.go
+++ b/internal/admission/handler_test.go
@@ -58,7 +58,8 @@ func TestSensorMutationHook(t *testing.T) {
 	decoder, err := admission.NewDecoder(scheme)
 	assert.NoError(t, err)
 
-	h.InjectDecoder(decoder)
+	err = h.InjectDecoder(decoder)
+	assert.NoError(t, err)
 
 	sen := sensor.Sensor{
 		ObjectMeta: v1.ObjectMeta{

--- a/internal/admission/handler_test.go
+++ b/internal/admission/handler_test.go
@@ -1,0 +1,178 @@
+package admission
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	sensor "github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1"
+	"github.com/kanopy-platform/argoslower/pkg/ratelimit"
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type fakeRateLimitGetter struct {
+	Rates map[string]*sensor.RateLimit
+	Err   error
+}
+
+func (frlg *fakeRateLimitGetter) RateLimit(namespace string) (*sensor.RateLimit, error) {
+	if r, ok := frlg.Rates[namespace]; ok {
+		return r, nil
+	} else {
+		return nil, frlg.Err
+	}
+}
+
+func newFakeRate() fakeRateLimitGetter {
+	return fakeRateLimitGetter{
+		Rates: map[string]*sensor.RateLimit{},
+	}
+}
+
+func TestSensorMutationHook(t *testing.T) {
+
+	t.Parallel()
+	frlg := newFakeRate()
+
+	testRate := &sensor.RateLimit{
+		Unit:            "Second",
+		RequestsPerUnit: int32(2),
+	}
+
+	frlg.Rates["test"] = testRate
+	frlg.Rates["novalue"] = nil
+
+	rc := ratelimit.NewRateLimitCalculatorOrDie("Second", int32(1))
+	defaultRate := rc.Calculate(nil, nil)
+
+	h := NewHandler(&frlg, rc)
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(sensor.AddToScheme(scheme))
+	decoder, err := admission.NewDecoder(scheme)
+	assert.NoError(t, err)
+
+	h.InjectDecoder(decoder)
+
+	sen := sensor.Sensor{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "test",
+		},
+		Spec: sensor.SensorSpec{},
+	}
+
+	tests := []struct {
+		description string
+		trigger     sensor.Trigger
+		ns          string
+		expected    float64
+	}{
+		{
+			description: "Trigger w/o k8s target",
+			trigger: sensor.Trigger{
+				Template: &sensor.TriggerTemplate{
+					Name: "nok8s",
+				},
+			},
+		},
+		{
+			description: "Trigger w/ namespace allowed k8s target and rate",
+			trigger: sensor.Trigger{
+				Template: &sensor.TriggerTemplate{
+					Name: "second",
+					K8s:  &sensor.StandardK8STrigger{},
+				},
+				RateLimit: testRate,
+			},
+		},
+		{
+			description: "Trigger w/ namespace allowed k8s target and hour rate",
+			trigger: sensor.Trigger{
+				Template: &sensor.TriggerTemplate{
+					Name: "hour",
+					K8s:  &sensor.StandardK8STrigger{},
+				},
+				RateLimit: &sensor.RateLimit{
+					Unit:            "Hour",
+					RequestsPerUnit: int32(3600),
+				},
+			},
+		},
+		{
+			description: "Trigger w/ default k8s target and hour rate",
+			trigger: sensor.Trigger{
+				Template: &sensor.TriggerTemplate{
+					Name: "default",
+					K8s:  &sensor.StandardK8STrigger{},
+				},
+				RateLimit: &defaultRate,
+			},
+			ns: "novalue",
+		},
+		{
+			description: "Trigger w/ default k8s target and big rate",
+			trigger: sensor.Trigger{
+				Template: &sensor.TriggerTemplate{
+					Name: "default",
+					K8s:  &sensor.StandardK8STrigger{},
+				},
+				RateLimit: testRate,
+			},
+			ns:       "novalue",
+			expected: 1,
+		},
+		{
+			description: "Trigger w/ too big k8s target and rate",
+			trigger: sensor.Trigger{
+				Template: &sensor.TriggerTemplate{
+					Name: "mutated",
+					K8s:  &sensor.StandardK8STrigger{},
+				},
+				RateLimit: &sensor.RateLimit{
+					Unit:            "Second",
+					RequestsPerUnit: int32(100),
+				},
+			},
+			expected: 2,
+		},
+	}
+
+	for _, test := range tests {
+
+		//set trigger on copy
+		csen := sen.DeepCopy()
+		csen.Spec.Triggers = []sensor.Trigger{test.trigger}
+
+		if test.ns != "" {
+			csen.Namespace = test.ns
+		}
+
+		sensorBytes, err := json.Marshal(csen)
+		assert.NoError(t, err)
+
+		//make admission request
+		ar := admissionv1.AdmissionRequest{
+			Object: runtime.RawExtension{
+				Raw: sensorBytes,
+			},
+		}
+
+		resp := h.Handle(context.TODO(), admission.Request{AdmissionRequest: ar})
+
+		//test allowed
+		assert.True(t, resp.Allowed, "request should be allowed")
+
+		//test patch bytes
+		assert.True(t, (len(resp.Patches) > 0) == (test.expected > 0), fmt.Sprintf("%s mutation expected", test.description))
+		for _, patch := range resp.Patches {
+			assert.Equal(t, "/spec/triggers/0/rateLimit/requestsPerUnit", patch.Path)
+			assert.Equal(t, float64(test.expected), patch.Value)
+		}
+	}
+}


### PR DESCRIPTION
This adds a handler to handle mutation of argo-events v1alpha1 sensor requests. Tests are inline for the handler.

