### PR TITLE
INFRA-3446 wire handler

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -8,9 +8,13 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/kanopy-platform/argoslower/internal/admission"
+	"github.com/kanopy-platform/argoslower/pkg/namespace"
+	"github.com/kanopy-platform/argoslower/pkg/ratelimit"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/informers"
@@ -23,6 +27,7 @@ import (
 	k8szap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
+	sensor "github.com/argoproj/argo-events/pkg/apis/sensor/v1alpha1"
 	sensorclient "github.com/argoproj/argo-events/pkg/client/sensor/clientset/versioned"
 	sinformerv1alpha1 "github.com/argoproj/argo-events/pkg/client/sensor/informers/externalversions"
 
@@ -33,6 +38,10 @@ var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("argoslower")
 )
+
+func setupScheme() {
+	utilruntime.Must(sensor.AddToScheme(scheme))
+}
 
 type RootCommand struct {
 	k8sFlags *genericclioptions.ConfigFlags
@@ -106,6 +115,8 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 
 	ctx := signals.SetupSignalHandler()
 
+	setupScheme()
+
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:                 scheme,
 		Host:                   "0.0.0.0",
@@ -151,6 +162,17 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 	namespacesInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(new interface{}) {},
 	})
+
+	rlua := viper.GetString("rate-limit-unit-annotation")
+	rlra := viper.GetString("requests-per-unit-annotation")
+
+	nsInformer := namespace.NewNamespaceInfo(namespacesInformer.Lister(), rlua, rlra)
+
+	drlu := viper.GetString("default-rate-limit-unit")
+	drlr := viper.GetInt32("default-requests-per-unit")
+	rlc := ratelimit.NewRateLimitCalculatorOrDie(drlu, drlr)
+
+	admission.NewHandler(nsInformer, rlc).SetupWithManager(mgr)
 
 	return mgr.Start(ctx)
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -155,13 +155,14 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 
 	k8sClientSet := kubernetes.NewForConfigOrDie(cfg)
 	k8sInformerFactory := informers.NewSharedInformerFactoryWithOptions(k8sClientSet, 1*time.Minute)
-	k8sInformerFactory.Start(wait.NeverStop)
-	k8sInformerFactory.WaitForCacheSync(wait.NeverStop)
 
 	namespacesInformer := k8sInformerFactory.Core().V1().Namespaces()
 	namespacesInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(new interface{}) {},
 	})
+
+	k8sInformerFactory.Start(wait.NeverStop)
+	k8sInformerFactory.WaitForCacheSync(wait.NeverStop)
 
 	rlua := viper.GetString("rate-limit-unit-annotation")
 	rlra := viper.GetString("requests-per-unit-annotation")


### PR DESCRIPTION
This creates an instance of the handler with all needed informers. No inline tests but you can:

1. Create an event controller
2. Create an event bus
3. Create a sensor with a k8s trigger w/o a rate limit
4. Confirm the rate limit gets set to 1/sec.


```
apiVersion: argoproj.io/v1alpha1
kind: EventBus
metadata:
  name: default
spec:
  jetstream:
    version: latest
...
---
apiVersion: argoproj.io/v1alpha1
kind: EventSource
metadata:
  name: file
spec:
  template:
    container:
      volumeMounts:
        - mountPath: /test-data
          name: test-data
    volumes:
      - name: test-data
        emptyDir: {}
  file:
    example:
      watchPathConfig:
        # directory to watch
        directory: /test-data/
        # path to watch
        path: x.txt
      # type of the event
      # supported types are: CREATE, WRITE, REMOVE, RENAME, CHMOD
      eventType: CREATE
...
---
apiVersion: argoproj.io/v1alpha1
kind: Sensor
metadata:
  name: file
spec:
  dependencies:
    - name: test-dep
      eventSourceName: file
      eventName: example
  triggers:
    - template:
        name: file-workflow-trigger
        k8s:
          operation: create
          source:
            resource:
              apiVersion: argoproj.io/v1alpha1
              kind: Workflow
              metadata:
                generateName: file-watcher-
              spec:
                entrypoint: whalesay
                templates:
                  -
                    container:
                      args:
                        - "hello" # it will get replaced by the event payload
                      command:
                        - cowsay
                      image: "docker/whalesay:latest"
                    name: whalesay
          parameters:
            - src:
                dependencyName: test-dep
                dataKey: name
              dest: spec.templates.0.container.args.0
      retryStrategy:
        steps: 3
...
```

