### PR TITLE
Lease Leadership Lock

### DIFF
--- a/examples/k8s/rbac.yaml
+++ b/examples/k8s/rbac.yaml
@@ -36,7 +36,6 @@ rules:
   - ""
   resources:
   - events
-  - configmaps
   verbs:
   - create
   - get
@@ -51,6 +50,7 @@ rules:
   - list
   - get
   - update
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -118,15 +118,16 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 	setupScheme()
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:                 scheme,
-		Host:                   "0.0.0.0",
-		Port:                   viper.GetInt("webhook-listen-port"),
-		CertDir:                viper.GetString("webhook-certs-dir"),
-		MetricsBindAddress:     fmt.Sprintf("0.0.0.0:%d", viper.GetInt("metrics-listen-port")),
-		HealthProbeBindAddress: ":8080",
-		LeaderElection:         true,
-		LeaderElectionID:       "argoslower",
-		DryRunClient:           dryRun,
+		Scheme:                     scheme,
+		Host:                       "0.0.0.0",
+		Port:                       viper.GetInt("webhook-listen-port"),
+		CertDir:                    viper.GetString("webhook-certs-dir"),
+		MetricsBindAddress:         fmt.Sprintf("0.0.0.0:%d", viper.GetInt("metrics-listen-port")),
+		HealthProbeBindAddress:     ":8080",
+		LeaderElection:             true,
+		LeaderElectionID:           "argoslower",
+		LeaderElectionResourceLock: "leases",
+		DryRunClient:               dryRun,
 	})
 
 	if err != nil {


### PR DESCRIPTION
Moves from the old default configmapsleases setting to only use leases.

Removed the configmap from RBAC and the controller doesn't complain. 