### PR TITLE
Feature cached iplister

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ lint-pipeline:
 test: tidy ## Run tests in local environment
 	golangci-lint run --timeout=5m $(PKG)
 	go test -cover -short -run=$(RUN) $(PKG)
+	go test -count 500 -race -short ./pkg/iplister/
 
 .PHONY: integration
 integration: tidy envtest ## Run integration tests with envtest

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ test: tidy ## Run tests in local environment
 	golangci-lint run --timeout=5m $(PKG)
 	go test -cover -short -run=$(RUN) $(PKG)
 	go test -count 500 -race -short ./pkg/iplister/
+	go test -bench -run=$(RUN) ./pkg/iplister/
 
 .PHONY: integration
 integration: tidy envtest ## Run integration tests with envtest

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,7 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/Shopify/sarama v1.38.0 h1:Q81EWxDT2Xs7kCaaiDGV30GyNCWd6K1Xmd4k2qpTWE8=
 github.com/Shopify/sarama v1.38.0/go.mod h1:djdek3V4gS0N9LZ+OhfuuM6rE1bEKeDffYY8UvsRNyM=
 github.com/Shopify/toxiproxy/v2 v2.5.0 h1:i4LPT+qrSlKNtQf5QliVjdP08GyAH8+BUIc9gT0eahc=
+github.com/Shopify/toxiproxy/v2 v2.5.0/go.mod h1:yhM2epWtAmel9CB8r2+L+PCmhH6yH2pITaPAo7jxJl0=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -89,6 +90,7 @@ github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMi
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
+github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
@@ -199,6 +201,7 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 h1:l5lAOZEym3oK3SQ2HBHWsJUfbNBiTXJDeW2QDxw9AQ0=
+github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
@@ -244,6 +247,7 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -350,7 +354,9 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v1.2.0 h1:42S6lae5dvLc7BrLu/0ugRtcFVjoJNMC/N3yZFZkDFs=
+github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hgR6gDIPg=
+github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
 github.com/spf13/afero v1.9.3 h1:41FoI0fD7OR7mGcKE/aOiLkGreyf8ifIOQmJANWogMk=
 github.com/spf13/afero v1.9.3/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
@@ -526,6 +532,7 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/iplister/cached.go
+++ b/pkg/iplister/cached.go
@@ -1,0 +1,103 @@
+package iplister
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type CachedIPLister struct {
+	reader       Reader
+	decoder      Decoder
+	timeout      time.Duration
+	lastSync     time.Time
+	syncInterval time.Duration
+	lock         *sync.RWMutex
+	ips          []string
+}
+
+func NewCachedIPLister(reader Reader, decoder Decoder) *CachedIPLister {
+	out := &CachedIPLister{
+		reader:       reader,
+		decoder:      decoder,
+		timeout:      defaultTimeout,
+		syncInterval: 5 * time.Minute,
+		lock:         &sync.RWMutex{},
+	}
+	out.setIPs()
+	return out
+}
+
+func (i *CachedIPLister) SetTimeout(t time.Duration) {
+	if i == nil {
+		return
+	}
+	i.lock.Lock()
+	i.timeout = t
+	i.lock.Unlock()
+}
+
+func (i *CachedIPLister) GetIPs() ([]string, error) {
+	var out []string
+	var err error
+	syncNow, bgSync := i.needSync()
+
+	if syncNow {
+		err = i.setIPs()
+	}
+
+	ipl := i.getIPs()
+	out = make([]string, len(ipl))
+	copy(out, ipl)
+
+	if bgSync {
+		go i.setIPs()
+	}
+	return out, err
+}
+
+func (i *CachedIPLister) needSync() (bool, bool) {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	if i.lastSync.IsZero() {
+		return true, false
+	}
+
+	if time.Now().Sub(i.lastSync) >= i.syncInterval {
+		return false, true
+	}
+
+	return false, false
+}
+func (i *CachedIPLister) getIPs() []string {
+	i.lock.RLock()
+	defer i.lock.RUnlock()
+	return i.ips
+}
+
+func (i *CachedIPLister) setIPs() error {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	// always update the sync time to keep from overwhelming the reader target
+	i.lastSync = time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), i.timeout)
+	defer cancel()
+
+	reader, err := i.reader.Data(ctx)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	ipList, err := i.decoder.Decode(reader)
+	if err != nil {
+		return err
+	}
+
+	if err := ValidateCIDRs(ipList); err != nil {
+		return err
+	}
+
+	i.ips = ipList
+	return nil
+}

--- a/pkg/iplister/cached.go
+++ b/pkg/iplister/cached.go
@@ -24,7 +24,7 @@ func NewCachedIPLister(reader Reader, decoder Decoder) *CachedIPLister {
 		syncInterval: 5 * time.Minute,
 		lock:         &sync.RWMutex{},
 	}
-	out.setIPs()
+	_ = out.setIPs()
 	return out
 }
 
@@ -51,7 +51,7 @@ func (i *CachedIPLister) GetIPs() ([]string, error) {
 	copy(out, ipl)
 
 	if bgSync {
-		go i.setIPs()
+		go i.setIPs() //nolint:errcheck
 	}
 	return out, err
 }
@@ -63,7 +63,7 @@ func (i *CachedIPLister) needSync() (bool, bool) {
 		return true, false
 	}
 
-	if time.Now().Sub(i.lastSync) >= i.syncInterval {
+	if time.Since(i.lastSync) >= i.syncInterval {
 		return false, true
 	}
 

--- a/pkg/iplister/cached.go
+++ b/pkg/iplister/cached.go
@@ -43,10 +43,7 @@ func (i *CachedIPLister) GetIPs() ([]string, error) {
 func (i *CachedIPLister) needSync() bool {
 	i.lock.Lock()
 	defer i.lock.Unlock()
-	if i.lastSync.IsZero() || time.Since(i.lastSync) >= i.syncInterval {
-		return true
-	}
-	return false
+	return i.lastSync.IsZero() || time.Since(i.lastSync) >= i.syncInterval
 }
 func (i *CachedIPLister) getIPs() []string {
 	i.lock.RLock()

--- a/pkg/iplister/iplister_test.go
+++ b/pkg/iplister/iplister_test.go
@@ -183,7 +183,7 @@ func TestCachedIPListerGetIPs(t *testing.T) {
 	for ; index <= 100; index++ {
 		ips, err = ipl.GetIPs()
 		assert.NoError(t, err)
-		assert.True(t, !contains(ips, "3.4.5.6/32"))
+		assert.NotContains(t, ips, "3.4.5.6/32")
 	}
 
 	ipl.lock.RLock()
@@ -191,7 +191,7 @@ func TestCachedIPListerGetIPs(t *testing.T) {
 	assert.True(t, index >= 100 && md.count <= (index+dcount), fmt.Sprint(index+dcount), fmt.Sprint(md.count))
 	ipl.lock.RUnlock()
 
-	// Test bg sync recovers from intermitant error
+	// Test sync recovers from intermittent error
 	ipl.lock.Lock()
 	mr.err = nil
 	ipl.lastSync = ipl.lastSync.Add(-5 * time.Minute)
@@ -199,7 +199,7 @@ func TestCachedIPListerGetIPs(t *testing.T) {
 
 	ips, err = ipl.GetIPs()
 	assert.NoError(t, err)
-	assert.True(t, contains(ips, "3.4.5.6/32"))
+	assert.Contains(t, ips, "3.4.5.6/32"))
 
 }
 
@@ -236,11 +236,3 @@ func BenchmarkCachedIPLister(b *testing.B) {
 	b.ReportMetric(ec, "Errors")
 }
 
-func contains(in []string, val string) bool {
-	for _, v := range in {
-		if v == val {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/iplister/iplister_test.go
+++ b/pkg/iplister/iplister_test.go
@@ -178,7 +178,7 @@ func TestCachedIPListerGetIPs(t *testing.T) {
 
 	ips, err = ipl.GetIPs()
 	assert.Error(t, err)
-	assert.True(t, !contains(ips, "3.4.5.6/32"))
+	assert.NotContains(t, ips, "3.4.5.6/32")
 	index := 0
 	for ; index <= 100; index++ {
 		ips, err = ipl.GetIPs()
@@ -199,7 +199,7 @@ func TestCachedIPListerGetIPs(t *testing.T) {
 
 	ips, err = ipl.GetIPs()
 	assert.NoError(t, err)
-	assert.Contains(t, ips, "3.4.5.6/32"))
+	assert.Contains(t, ips, "3.4.5.6/32")
 
 }
 
@@ -235,4 +235,3 @@ func BenchmarkCachedIPLister(b *testing.B) {
 
 	b.ReportMetric(ec, "Errors")
 }
-

--- a/pkg/iplister/iplister_test.go
+++ b/pkg/iplister/iplister_test.go
@@ -2,6 +2,7 @@ package iplister
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -104,4 +105,134 @@ func TestValidateCIDRs(t *testing.T) {
 		err := ValidateCIDRs(test.input)
 		assert.Equal(t, test.wantErr, err != nil, test.name)
 	}
+}
+
+func TestNewCachedIPLister(t *testing.T) {
+	t.Parallel()
+
+	ipl := NewCachedIPLister(&mockReader{}, &mockDecoder{})
+	assert.Equal(t, defaultTimeout, ipl.timeout)
+
+	ipl.SetTimeout(500 * time.Minute)
+	assert.Equal(t, (500 * time.Minute), ipl.timeout)
+}
+
+func TestCachedIPListerGetIPs(t *testing.T) {
+	t.Parallel()
+
+	fakeData := "1.2.3.4/32"
+	decoderData := []string{fakeData}
+
+	mr := &mockReader{
+		ret: fakeData,
+		err: nil,
+	}
+	md := &mockDecoder{
+		ret: decoderData,
+		err: nil,
+	}
+	ipl := NewCachedIPLister(mr, md)
+
+	// Test ip list population at creation time
+	ipl.lock.Lock()
+	assert.Equal(t, 1, md.count)
+	ipl.lock.Unlock()
+
+	// Test ip list is returned from cache
+	ips, err := ipl.GetIPs()
+	assert.NoError(t, err)
+	assert.Contains(t, ips, "1.2.3.4/32")
+
+	ipl.lock.Lock()
+	assert.Equal(t, 1, md.count)
+	ipl.lock.Unlock()
+
+	// Test ip list is returned from cache
+	ipl.lock.Lock()
+	md.ret = []string{"2.3.4.5/32"}
+	ipl.lock.Unlock()
+	ips, err = ipl.GetIPs()
+	assert.NoError(t, err)
+	assert.NotContains(t, ips, "2.3.4.5/32")
+
+	ipl.lock.Lock()
+	assert.Equal(t, 1, md.count)
+	ipl.lock.Unlock()
+
+	// Test 5min background sync for stale ip lists
+	ipl.lock.Lock()
+	ipl.lastSync = ipl.lastSync.Add(-5 * time.Minute)
+	ipl.lock.Unlock()
+
+	ips, err = ipl.GetIPs()
+	assert.NoError(t, err)
+
+	ipl.lock.Lock()
+	index := md.count
+	ipl.lock.Unlock()
+
+	for !contains(ips, "2.3.4.5/32") {
+		ips, err = ipl.GetIPs()
+		assert.NoError(t, err)
+		index += 1
+
+		if index >= 1000 {
+			break
+		}
+	}
+
+	assert.True(t, contains(ips, "2.3.4.5/32"))
+	ipl.lock.RLock()
+	assert.True(t, mr.count <= index)
+	assert.True(t, md.count <= index)
+	ipl.lock.RUnlock()
+
+	// Test failed bg sync retains stale ip list
+	ipl.lock.Lock()
+	md.ret = []string{"3.4.5.6/32"}
+	mr.err = fmt.Errorf("slow down")
+	ipl.lastSync = ipl.lastSync.Add(-5 * time.Minute)
+	ipl.lock.Unlock()
+
+	index = 0
+	for ; index <= 100; index++ {
+		ips, err = ipl.GetIPs()
+		assert.NoError(t, err)
+		assert.True(t, !contains(ips, "3.4.5.6/32"))
+	}
+
+	assert.True(t, !contains(ips, "3.4.5.6/32"))
+	ipl.lock.RLock()
+	assert.True(t, mr.count <= index)
+	assert.True(t, md.count <= index)
+	ipl.lock.RUnlock()
+
+	// Test bg sync recovers from intermitant error
+	ipl.lock.Lock()
+	mr.err = nil
+	ipl.lastSync = ipl.lastSync.Add(-5 * time.Minute)
+	ipl.lock.Unlock()
+
+	index = 0
+
+	for !contains(ips, "3.4.5.6/32") {
+		ips, err = ipl.GetIPs()
+		assert.NoError(t, err)
+		index += 1
+
+		if index >= 1000 {
+			break
+		}
+	}
+
+	assert.True(t, contains(ips, "3.4.5.6/32"))
+}
+
+func contains(in []string, val string) bool {
+	for _, v := range in {
+		if v == val {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/iplister/iplister_test.go
+++ b/pkg/iplister/iplister_test.go
@@ -178,6 +178,7 @@ func TestCachedIPListerGetIPs(t *testing.T) {
 
 	ips, err = ipl.GetIPs()
 	assert.Error(t, err)
+	assert.True(t, !contains(ips, "3.4.5.6/32"))
 	index := 0
 	for ; index <= 100; index++ {
 		ips, err = ipl.GetIPs()

--- a/pkg/iplister/iplister_test.go
+++ b/pkg/iplister/iplister_test.go
@@ -165,7 +165,7 @@ func TestCachedIPListerGetIPs(t *testing.T) {
 
 	ips, err = ipl.GetIPs()
 	assert.NoError(t, err)
-	assert.True(t, contains(ips, "2.3.4.5/32"))
+	assert.Contains(t, ips, "2.3.4.5/32")
 
 	// Test failed bg sync retains stale ip list
 	ipl.lock.Lock()


### PR DESCRIPTION
This adds a cached ip lister type that serves requests out of an ip cache and provides lazy loading for cache refresh. 
Tests are inline and race condition testing for this package has been added to the Makefile. 

Locally `go test -count 50000 -race ./pkg/iplister/` passes on repeated runs. 