### PR TITLE
Feature Enforce Shared Secret Length

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,8 @@ require (
 	github.com/stretchr/testify v1.8.2
 	go.uber.org/zap v1.24.0
 	gopkg.in/yaml.v3 v3.0.1
-	istio.io/api v0.0.0-20230711220847-08f4f4a00d6e
-	istio.io/client-go v1.16.6
+	istio.io/api v0.0.0-20231011001129-b6bd6cd1b885
+	istio.io/client-go v1.17.8
 	k8s.io/api v0.26.0
 	k8s.io/apimachinery v0.26.0
 	k8s.io/cli-runtime v0.25.16

--- a/go.sum
+++ b/go.sum
@@ -792,10 +792,10 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-istio.io/api v0.0.0-20230711220847-08f4f4a00d6e h1:b0Cpo1tDarHUeLc9zYR71mvl6gUKgK46vEPW5y5iEEc=
-istio.io/api v0.0.0-20230711220847-08f4f4a00d6e/go.mod h1:hQkF0Q19MCmfOTre/Sg4KvrwwETq45oaFplnBm2p4j8=
-istio.io/client-go v1.16.6 h1:PV1Tn/RHJ+3JjN/irVU1Fj8XcshsTG9QOHj6eanwu58=
-istio.io/client-go v1.16.6/go.mod h1:NiPUMyvuiJboMj3mUPOq0Ae3BM2nY097ewarHgwo/Lg=
+istio.io/api v0.0.0-20231011001129-b6bd6cd1b885 h1:I8mtxnP4kp8leqQ4sel2AxWON5gw18W6h13aE9O5g7M=
+istio.io/api v0.0.0-20231011001129-b6bd6cd1b885/go.mod h1:owGDRg9uqMob8CN1gxaOzk6nJxnbT8wrP7PmggpJHHY=
+istio.io/client-go v1.17.8 h1:RtP3G8uPaFm+Q+NYXFcdiRSj5GwSZnh/WnhHOJmsp10=
+istio.io/client-go v1.17.8/go.mod h1:rW8Lj0iHDvB0rXbryn6PNfYh3cK6ueeO47cm+Y23NCg=
 k8s.io/api v0.25.16 h1:6VsSxn0vCdHuAVh82EZCKoM457LuUpQQb6YXfQunz7Q=
 k8s.io/api v0.25.16/go.mod h1:7pehrlB/DJ0qzxicMELX7IZlgL6J5lnSOBPey/cuGBs=
 k8s.io/apiextensions-apiserver v0.25.16 h1:M03IXtKn2dptWxGtqrh3ZK2xeIFTCKsZBSaUpRCFQV8=

--- a/pkg/ingress/v1/istio/client.go
+++ b/pkg/ingress/v1/istio/client.go
@@ -257,13 +257,12 @@ func (ic *IstioConfig) ConfigureVS(url string, gw, svc, es types.NamespacedName,
 								// https://tools.ietf.org/html/rfc6750#section-2.1
 								// but it aligns with the desired length requirements
 								// and implementation by argo events
-								Regex: `^Bearer\\s+\\S{0,11}\\s*$`,
+								Regex: `^Bearer\s+\S{0,11}\s*$`,
 							},
 						},
 					},
 				},
 			},
-			Rewrite: &netv1beta1.HTTPRewrite{Uri: "/"},
 		}
 		index++
 		routes[index] = &netv1beta1.HTTPRoute{

--- a/pkg/ingress/v1/istio/client_test.go
+++ b/pkg/ingress/v1/istio/client_test.go
@@ -82,7 +82,7 @@ func TestConfigureVS(t *testing.T) {
 				assert.True(t, strings.Contains(urlPrefix, fmt.Sprintf("/%s/%s", test.es.Namespace, test.es.Name)), test.name)
 				headerMatch := route.Match[0].Headers["authorization"].GetRegex()
 				assert.NotNil(t, headerMatch, test.name)
-				assert.Equal(t, `^Bearer\\s+\\S{0,11}\\s*$`, headerMatch, test.name)
+				assert.Equal(t, `^Bearer\s+\S{0,11}\s*$`, headerMatch, test.name)
 				directResponseCount++
 				continue
 			}

--- a/pkg/ingress/v1/istio/client_test.go
+++ b/pkg/ingress/v1/istio/client_test.go
@@ -78,6 +78,7 @@ func TestConfigureVS(t *testing.T) {
 		for _, route := range vs.Spec.Http {
 			if route.DirectResponse != nil {
 				urlPrefix := route.Match[0].Uri.GetPrefix()
+				assert.Nil(t, route.Rewrite, test.name)
 				assert.True(t, strings.Contains(urlPrefix, fmt.Sprintf("/%s/%s", test.es.Namespace, test.es.Name)), test.name)
 				headerMatch := route.Match[0].Headers["authorization"].GetRegex()
 				assert.NotNil(t, headerMatch, test.name)

--- a/pkg/ingress/v1/istio/client_test.go
+++ b/pkg/ingress/v1/istio/client_test.go
@@ -2,6 +2,7 @@ package istio
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	common "github.com/kanopy-platform/argoslower/pkg/ingress"
@@ -73,7 +74,18 @@ func TestConfigureVS(t *testing.T) {
 		assert.Equal(t, test.es.Name, vs.Labels[common.EventSourceNameString], test)
 		assert.Equal(t, test.es.Namespace, vs.Labels[common.EventSourceNamespaceString], test)
 
+		var directResponseCount int
 		for _, route := range vs.Spec.Http {
+			if route.DirectResponse != nil {
+				urlPrefix := route.Match[0].Uri.GetPrefix()
+				assert.True(t, strings.Contains(urlPrefix, fmt.Sprintf("/%s/%s", test.es.Namespace, test.es.Name)), test.name)
+				headerMatch := route.Match[0].Headers["authorization"].GetRegex()
+				assert.NotNil(t, headerMatch, test.name)
+				assert.Equal(t, `^Bearer\\s+\\S{0,11}\\s*$`, headerMatch, test.name)
+				directResponseCount++
+				continue
+			}
+
 			// destination should be the fully qualified internal service name
 			assert.Equal(t, fmt.Sprintf("%s.%s.svc.cluster.local", test.svc.Name, test.svc.Namespace), route.Route[0].Destination.Host, test.name)
 
@@ -83,6 +95,7 @@ func TestConfigureVS(t *testing.T) {
 			urlPrefix := route.Match[0].Uri.GetPrefix()
 			assert.Equal(t, fmt.Sprintf("/%s/%s%s/", test.es.Namespace, test.es.Name, ep.Path), urlPrefix, test.name)
 		}
+		assert.Equal(t, directResponseCount, len(test.endpoints), test.name)
 	}
 }
 


### PR DESCRIPTION
This PR adds a virtual service routing rule to enforce a minimal length requirement on the required shared secret for the event webhook receives published by the controller. VirtualService is a poor place to enforce this but the controller has no prior knowledge of the contents of the referenced secret.

Parsing and evaluating the RE2 expressions isn't possible without introducing C dependencies to the testing framework. 