### PR TITLE
Feature: Reject unknown webhook sources

### DIFF
--- a/internal/admission/eventsource/handler.go
+++ b/internal/admission/eventsource/handler.go
@@ -70,7 +70,7 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 		return admission.Allowed("No modifications needed")
 	}
 
-	if !h.knownSources[sourceValue] {
+	if _, ok := h.knownSources[sourceValue]; !ok {
 		return admission.Denied(fmt.Sprintf("Unknown webhook source '%s'. Only known webhook sources are allowed.", sourceValue))
 	}
 

--- a/internal/admission/eventsource/handler.go
+++ b/internal/admission/eventsource/handler.go
@@ -24,12 +24,14 @@ type Handler struct {
 	annotationKey string
 	meshChecker   MeshChecker
 	decoder       *admission.Decoder
+	knownSources  map[string]bool
 }
 
-func NewHandler(mc MeshChecker) *Handler {
+func NewHandler(mc MeshChecker, knownSources map[string]bool) *Handler {
 	return &Handler{
 		annotationKey: DefaultAnnotationKey,
 		meshChecker:   mc,
+		knownSources:  knownSources,
 	}
 }
 
@@ -62,10 +64,14 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	_, ok := out.Annotations[h.annotationKey]
+	sourceValue, ok := out.Annotations[h.annotationKey]
 	if !ok {
 		log.V(1).Info("Annotation not found, ignoring eventsource")
 		return admission.Allowed("No modifications needed")
+	}
+
+	if !h.knownSources[sourceValue] {
+		return admission.Denied(fmt.Sprintf("Unknown webhook source '%s'. Only known webhook sources are allowed.", sourceValue))
 	}
 
 	onMesh, err := h.meshChecker.OnMesh(out.Namespace)

--- a/internal/admission/handler_test.go
+++ b/internal/admission/handler_test.go
@@ -66,6 +66,10 @@ func TestRoutingHandler(t *testing.T) {
 		Mesh: true,
 	}
 
+	knownSources := map[string]bool{
+		"github": true,
+	}
+
 	tests := map[string]struct {
 		sensor *sensor.Handler
 		es     *eventsource.Handler
@@ -74,8 +78,8 @@ func TestRoutingHandler(t *testing.T) {
 	}{
 		"empty":      {sdeny: true, esdeny: true},
 		"sensoronly": {sensor: sensor.NewHandler(&frlg, rc), esdeny: true},
-		"esonly":     {es: eventsource.NewHandler(fmc), sdeny: true},
-		"both":       {sensor: sensor.NewHandler(&frlg, rc), es: eventsource.NewHandler(fmc)},
+		"esonly":     {es: eventsource.NewHandler(fmc, knownSources), sdeny: true},
+		"both":       {sensor: sensor.NewHandler(&frlg, rc), es: eventsource.NewHandler(fmc, knownSources)},
 	}
 
 	for name, test := range tests {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -245,8 +245,6 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 		filteredIstioInformerFactory.Start(wait.NeverStop)
 		filteredIstioInformerFactory.WaitForCacheSync(wait.NeverStop)
 
-		eventSourceHandler = esadd.NewHandler(nsInformer)
-
 		gws := stringutils.StringToMap(viper.GetString("gateway-selector"), ",", "=")
 		if len(gws) == 0 {
 			return fmt.Errorf("Invalid gateway-selector: %s", viper.GetString("gateway-selector"))
@@ -269,6 +267,8 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
+
+		eventSourceHandler = esadd.NewHandler(nsInformer, escc.GetKnownSources())
 
 		esi.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc: func(new interface{}) {}})

--- a/internal/controllers/eventsource/controller.go
+++ b/internal/controllers/eventsource/controller.go
@@ -52,6 +52,14 @@ func (c *EventSourceIngressControllerConfig) SetIPGetter(name string, getter v1.
 	c.ipGetters[name] = getter
 }
 
+func (c *EventSourceIngressControllerConfig) GetKnownSources() map[string]bool {
+	knownSources := make(map[string]bool)
+	for source := range c.ipGetters {
+		knownSources[source] = true
+	}
+	return knownSources
+}
+
 func NewEventSourceIngressController(esl eslister.EventSourceLister, svcl corev1lister.ServiceLister, config EventSourceIngressControllerConfig, igc v1.IngressConfigurator) *EventSourceIngressController {
 	return &EventSourceIngressController{
 		esLister:      esl,

--- a/internal/controllers/eventsource/controller_test.go
+++ b/internal/controllers/eventsource/controller_test.go
@@ -341,3 +341,27 @@ func TestServiceToPortMapping(t *testing.T) {
 	}
 
 }
+
+// Faking IPGetter interface
+type FakeIPGetter struct{}
+
+func (f *FakeIPGetter) GetIPs() ([]string, error) {
+	return []string{"0.0.0.0/32"}, nil
+}
+
+func TestGetKnownSources(t *testing.T) {
+	escConfig := NewEventSourceIngressControllerConfig()
+
+	// Mimic the cli configuration
+	escConfig.SetIPGetter("github", &FakeIPGetter{})
+	escConfig.SetIPGetter("officeips", &FakeIPGetter{})
+
+	knownSources := escConfig.GetKnownSources()
+
+	expectedSources := map[string]bool{
+		"github":    true,
+		"officeips": true,
+	}
+
+	assert.Equal(t, expectedSources, knownSources)
+}


### PR DESCRIPTION
Adds a validation check in the eventsource handler to ensure that the value of `v1alpha1.argoslower.kanopy-platform/known-source` is supported. 

The source of truth is taken from the EventSourceIngressControllerConfig ipGetter.

### Testing
TBC