### PR TITLE
Update cert-manager manifest

### DIFF
--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -1,12 +1,12 @@
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-argoslower
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: argoslower


### PR DESCRIPTION
Updating example manifests to `apiVersion: cert-manager.io/v1` because v1alpha is deprecated.